### PR TITLE
update brew install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Use Chocolately (from the terminal).<br />
 <br />
 <strong>OS X:</strong><br />
 Use Homebrew (from the terminal).<br />
-<code>brew cask install rstudio</code></td>
+<code>brew install --cask rstudio</code></td>
 <td style="text-align: center;">Skim the <a href="https://www.rstudio.org/links/ide_cheat_sheet">cheatsheet</a></td>
 </tr>
 <tr class="odd">
@@ -133,7 +133,7 @@ Use chocolately.<br />
 <br />
 <strong>OS X:</strong><br />
 Use Homebrew (from the terminal).<br />
-<code>brew cask install docker</code><br />
+<code>brew install --cask docker</code><br />
 <br />
 <strong>Linux:</strong><br />
 Follow steps described in: <a href="https://docs.docker.com/engine/install/linux-postinstall/">Post-installation steps for Linux</a></td>

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ sessioninfo::session_info()
     ##  collate  en_US.UTF-8                 
     ##  ctype    en_US.UTF-8                 
     ##  tz       Etc/UTC                     
-    ##  date     2021-03-23                  
+    ##  date     2021-05-01                  
     ## 
     ## ─ Packages ───────────────────────────────────────────────────────────────────
     ##  package     * version date       lib source        

--- a/data/resources.csv
+++ b/data/resources.csv
@@ -19,7 +19,7 @@ Use Chocolately (from the terminal).\
 \
 **OS X:**\
 Use Homebrew (from the terminal).\
-`brew cask install rstudio`
+`brew install --cask rstudio`
 ",Skim the [cheatsheet](https://www.rstudio.org/links/ide_cheat_sheet)
 rmarkdown,"Within Rstudio, type into the R-console:\
 `install.packages(""rmarkdown"")`
@@ -55,7 +55,7 @@ Use chocolately.\
 \
 **OS X:**\
 Use Homebrew (from the terminal).\
-`brew cask install docker`\
+`brew install --cask docker`\
 \
 **Linux:**\
 Follow steps described in: [Post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/)","Read [An Introduction to Rocker: Docker


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524